### PR TITLE
Added backup playbook for grafana database backup by rclone

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -1,5 +1,8 @@
 ---
 grafana_oauth_client_id: "grafana"
+grafana_backup_enabled: false
+grafana_backup_schedule: "*-*-* 03:00:00"
+grafana_backup_remotes: []
 oauth2proxy_oauth_client_id: "oauth2proxy"
 metrics_write_user: "metrics"
 dex_local_admin: false

--- a/group_vars/prod/vars.yml
+++ b/group_vars/prod/vars.yml
@@ -12,3 +12,11 @@ victoriametrics_web_allowed_editor: "allowed_groups=beyond-all-reason:monitoring
 grafana_role_attribute_path: "contains(groups[*], 'beyond-all-reason:monitoring-admins') && 'Admin' || contains(groups[*], 'beyond-all-reason:monitoring-editors') && 'Editor' || contains(groups[*], 'beyond-all-reason:monitoring-viewers') && 'Viewer' || 'None'"
 monitoring_write_instance_dev: false # for the client role
 monitoring_metrics_write_password: "{{ vault_metrics_write_password_raw }}"
+grafana_backup_enabled: true
+grafana_backup_remotes:
+  - name: primary
+    bucket: "grafana-backups"
+    rclone_config: |
+      type = gcs
+      service_account_file = /etc/rclone/primary.json
+    credentials_file_content: "{{ vault_grafana_backup_primary_credentials }}"

--- a/roles/monitoring/handlers/main.yml
+++ b/roles/monitoring/handlers/main.yml
@@ -27,3 +27,8 @@
   ansible.builtin.systemd_service:
     name: oauth2proxy.service
     state: restarted
+- name: Restart grafana-backup timer
+  ansible.builtin.systemd_service:
+    name: grafana-backup.timer
+    state: restarted
+    daemon_reload: true

--- a/roles/monitoring/tasks/backup.yml
+++ b/roles/monitoring/tasks/backup.yml
@@ -1,0 +1,65 @@
+---
+- name: Create rclone config directory
+  ansible.builtin.file:
+    path: /etc/rclone
+    state: directory
+    mode: "0700"
+
+- name: Write remote credentials files
+  ansible.builtin.copy:
+    dest: "/etc/rclone/{{ item.name }}.json"
+    content: "{{ item.credentials_file_content }}"
+    mode: "0600"
+  loop: "{{ grafana_backup_remotes }}"
+  when: item.credentials_file_content is defined
+  no_log: true
+
+- name: Write rclone config
+  ansible.builtin.template:
+    src: rclone.conf.j2
+    dest: /etc/rclone/rclone.conf
+    mode: "0600"
+  no_log: true
+
+- name: Write grafana backup script
+  ansible.builtin.template:
+    src: grafana-backup.sh.j2
+    dest: /usr/local/sbin/grafana-backup
+    mode: "0750"
+
+- name: Create grafana-backup systemd service unit
+  ansible.builtin.copy:
+    dest: /etc/systemd/system/grafana-backup.service
+    mode: "0644"
+    content: |
+      [Unit]
+      Description=Grafana database backup
+      After=grafana.service
+
+      [Service]
+      Type=oneshot
+      ExecStart=/usr/local/sbin/grafana-backup
+
+- name: Create grafana-backup systemd timer
+  ansible.builtin.copy:
+    dest: /etc/systemd/system/grafana-backup.timer
+    mode: "0644"
+    content: |
+      [Unit]
+      Description=Daily Grafana database backup
+
+      [Timer]
+      OnCalendar={{ grafana_backup_schedule }}
+      Persistent=true
+
+      [Install]
+      WantedBy=timers.target
+  notify: Restart grafana-backup timer
+
+- name: Enable and start grafana-backup timer
+  ansible.builtin.systemd_service:
+    name: grafana-backup.timer
+    enabled: true
+    state: started
+    daemon_reload: true
+

--- a/roles/monitoring/tasks/main.yml
+++ b/roles/monitoring/tasks/main.yml
@@ -8,6 +8,10 @@
 - name: Set up containers
   ansible.builtin.import_tasks: containers.yml
   tags: containers
+- name: Set up backups
+  ansible.builtin.import_tasks: backup.yml
+  when: grafana_backup_enabled
+  tags: backup
 - name: Attach client montoring
   ansible.builtin.import_role:
     name: client

--- a/roles/monitoring/tasks/system.yml
+++ b/roles/monitoring/tasks/system.yml
@@ -16,6 +16,8 @@
       - man
       - nano
       - podman
+      - rclone
+      - sqlite3
       - tmux
       - ufw
       - unattended-upgrades

--- a/roles/monitoring/templates/grafana-backup.sh.j2
+++ b/roles/monitoring/templates/grafana-backup.sh.j2
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -euo pipefail
+umask 077
+
+DATE=$(date +%Y%m%d-%H%M%S)
+BACKUP_DB="/tmp/grafana-backup-${DATE}.db"
+BACKUP_FILE="${BACKUP_DB}.gz"
+
+trap 'rm -f "${BACKUP_DB}" "${BACKUP_FILE}"' EXIT
+
+MOUNTPOINT=$(podman volume inspect grafana_data --format {% raw %}'{{.Mountpoint}}'{% endraw %})
+sqlite3 "${MOUNTPOINT}/grafana.db" ".backup ${BACKUP_DB}"
+gzip "${BACKUP_DB}"
+
+set +e
+FAILED=0
+{% for remote in grafana_backup_remotes %}
+if ! rclone --config /etc/rclone/rclone.conf copy "${BACKUP_FILE}" "{{ remote.name }}:{{ remote.bucket }}/grafana/"; then
+    echo "ERROR: Upload to remote '{{ remote.name }}' failed" >&2
+    FAILED=1
+fi
+{% endfor %}
+
+exit "${FAILED}"

--- a/roles/monitoring/templates/rclone.conf.j2
+++ b/roles/monitoring/templates/rclone.conf.j2
@@ -1,0 +1,5 @@
+{% for remote in grafana_backup_remotes %}
+[{{ remote.name }}]
+{{ remote.rclone_config | trim }}
+
+{% endfor %}


### PR DESCRIPTION
Closed #1 

Playbook is configured for daily backups and upload to one or more targets. Backups are compressed with gzip.

Example when we want more than one remote:

```
  grafana_backup_remotes:
    - name: primary
      bucket: "my-gcs-bucket"
      rclone_config: |
        type = gcs
        service_account_file = /etc/rclone/primary.json
      credentials_file_content: "{{ vault_backup_primary_credentials }}"

    - name: secondary
      bucket: "my-s3-bucket"
      rclone_config: |
        type = s3
        provider = AWS
        region = eu-central-1
        access_key_id = {{ vault_backup_s3_key_id }}
        secret_access_key = {{ vault_backup_s3_secret }}
```

I do not have pass for vault, so you need to add credentials for GCS :)